### PR TITLE
feat: generator: allow tsconfig path as module option

### DIFF
--- a/packages/nestjs-trpc/lib/generators/__tests__/generator.module.spec.ts
+++ b/packages/nestjs-trpc/lib/generators/__tests__/generator.module.spec.ts
@@ -1,0 +1,23 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GeneratorModule } from '../generator.module';
+
+describe('GeneratorModule', () => {
+  let generatorModule: GeneratorModule;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        GeneratorModule.forRoot({
+            rootModuleFilePath: '',
+            tsConfigFilePath: './tsconfig.json',
+        }),
+      ],
+    }).compile();
+
+    generatorModule = module.get<GeneratorModule>(GeneratorModule);
+  });
+
+  it('should be defined', () => {
+    expect(generatorModule).toBeDefined();
+  });
+});

--- a/packages/nestjs-trpc/lib/generators/generator.interface.ts
+++ b/packages/nestjs-trpc/lib/generators/generator.interface.ts
@@ -6,4 +6,5 @@ export interface GeneratorModuleOptions {
   context?: Class<TRPCContext>;
   outputDirPath?: string;
   schemaFileImports?: Array<SchemaImports>;
+  tsConfigFilePath?: string;
 }

--- a/packages/nestjs-trpc/lib/generators/generator.module.ts
+++ b/packages/nestjs-trpc/lib/generators/generator.module.ts
@@ -58,7 +58,10 @@ export class GeneratorModule implements OnModuleInit {
       checkJs: true,
       esModuleInterop: true,
     };
-    const project = new Project({ compilerOptions: defaultCompilerOptions });
+    const project = new Project({
+      compilerOptions: defaultCompilerOptions,
+      tsConfigFilePath: options.tsConfigFilePath,
+    });
 
     const appRouterSourceFile = project.createSourceFile(
       path.resolve(options.outputDirPath ?? './', 'server.ts'),


### PR DESCRIPTION
Fix https://github.com/KevinEdry/nestjs-trpc/issues/18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for specifying a TypeScript configuration file path in the `GeneratorModule`

- **Tests**
	- Introduced a new test suite for the `GeneratorModule` to validate its initialization

The changes enhance the module's configuration flexibility by allowing custom TypeScript configuration file paths during project generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->