### PR TITLE
feat: generator: allow tsconfig path as module option

### DIFF
--- a/packages/nestjs-trpc/lib/interfaces/module-options.interface.ts
+++ b/packages/nestjs-trpc/lib/interfaces/module-options.interface.ts
@@ -20,6 +20,11 @@ export interface TRPCModuleOptions {
   autoSchemaFile?: string;
 
   /**
+   * Path to project tsconfig.
+   */
+  tsConfigFilePath?: string;
+
+  /**
    * Specifies additional imports for the schema file. This array can include functions, objects, or Zod schemas.
    * While `nestjs-trpc` typically handles imports automatically, this option allows manual inclusion of imports for exceptional cases.
    * Use this property only when automatic import resolution is insufficient.

--- a/packages/nestjs-trpc/lib/trpc.module.ts
+++ b/packages/nestjs-trpc/lib/trpc.module.ts
@@ -54,6 +54,7 @@ export class TRPCModule implements OnModuleInit {
       imports.push(
         GeneratorModule.forRoot({
           outputDirPath: options.autoSchemaFile,
+          tsConfigFilePath: options.tsConfigFilePath,
           rootModuleFilePath: callerFilePath,
           schemaFileImports: options.schemaFileImports,
           context: options.context,


### PR DESCRIPTION
Allow `tsConfigFilePath` in `TRPCModuleOptions`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added an optional configuration option `tsConfigFilePath` to customize TypeScript configuration file path in TRPC module initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->