### PR TITLE
feat: generator: flatten enum to literal value

### DIFF
--- a/packages/nestjs-trpc/lib/generators/__tests__/__snapshots__/procedure.generator.spec.ts.snap
+++ b/packages/nestjs-trpc/lib/generators/__tests__/__snapshots__/procedure.generator.spec.ts.snap
@@ -19,3 +19,14 @@ exports[`ProcedureGenerator flattenZodSchema should flatten all chained call exp
             .describe('Options to find many items'),
         })"
 `;
+
+exports[`ProcedureGenerator flattenZodSchema should flatten enum to literal value 1`] = `
+"z.object({
+          options: z
+            .object({
+              userId: z.string().describe('ID of the current user'),
+              type: z.literal('Normal').describe('Type of the item')
+            })
+            .describe('Options to find many items'),
+        })"
+`;

--- a/packages/nestjs-trpc/lib/generators/__tests__/procedure.generator.spec.ts
+++ b/packages/nestjs-trpc/lib/generators/__tests__/procedure.generator.spec.ts
@@ -107,5 +107,36 @@ describe('ProcedureGenerator', () => {
       const result = procedureGenerator.flattenZodSchema(node, sourceFile, project, node.getText());
       expect(result).toMatchSnapshot();
     });
+
+    it('should flatten enum to literal value', () => {
+      project.createSourceFile(
+        "types.ts",
+        `
+        export enum TypeEnum { Normal = 'Normal', Unknown = 'Unknown' };
+        `,
+        { overwrite: true }
+      );
+      const sourceFile: SourceFile = project.createSourceFile(
+        "test.ts",
+        `
+        import { z } from 'zod';
+        import { TypeEnum } from './types';
+
+        const FindManyInput = z.object({
+          options: z
+            .object({
+              userId: z.string().describe('ID of the current user'),
+              type: z.literal(TypeEnum.Normal).describe('Type of the item')
+            })
+            .describe('Options to find many items'),
+        });
+        `,
+        { overwrite: true }
+      );
+
+      const node = sourceFile.getDescendantsOfKind(SyntaxKind.Identifier).find((identifier) => identifier.getText() === "FindManyInput") as Identifier;
+      const result = procedureGenerator.flattenZodSchema(node, sourceFile, project, node.getText());
+      expect(result).toMatchSnapshot();
+    });
   });
 });


### PR DESCRIPTION
This fix helps to flatten enum names to enum values.

An example:

```typescript
// types.ts
export enum TypeEnum { Normal = 'Normal', Unknown = 'Unknown' };
```

```typescript
// test.ts
import { z } from 'zod';
import { TypeEnum } from './types';

const FindManyInput = z.object({
  options: z
    .object({
      userId: z.string().describe('ID of the current user'),
      type: z.literal(TypeEnum.Normal).describe('Type of the item')
    })
    .describe('Options to find many items'),
});
```

Before the fix, it generates: `type: z.literal(export enum TypeEnum { Normal = 'Normal', Unknown = 'Unknown' }).describe('Type of the item')`

After the fix, it generates: `type: z.literal('Normal').describe('Type of the item')`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Added a new test case to verify enum literal value flattening in the procedure generator test suite.

- **Improvements**
	- Enhanced schema flattening logic to better handle property access expressions and enum values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->