### PR TITLE
feat: trpc-module: allow configuring `rootModuleFilePath` in options

### DIFF
--- a/packages/nestjs-trpc/lib/interfaces/module-options.interface.ts
+++ b/packages/nestjs-trpc/lib/interfaces/module-options.interface.ts
@@ -25,6 +25,11 @@ export interface TRPCModuleOptions {
   tsConfigFilePath?: string;
 
   /**
+   * The file path of the module that calls the TRPCModule.
+   */
+  rootModuleFilePath?: string;
+
+  /**
    * Specifies additional imports for the schema file. This array can include functions, objects, or Zod schemas.
    * While `nestjs-trpc` typically handles imports automatically, this option allows manual inclusion of imports for exceptional cases.
    * Use this property only when automatic import resolution is insufficient.

--- a/packages/nestjs-trpc/lib/trpc.module.ts
+++ b/packages/nestjs-trpc/lib/trpc.module.ts
@@ -55,7 +55,7 @@ export class TRPCModule implements OnModuleInit {
         GeneratorModule.forRoot({
           outputDirPath: options.autoSchemaFile,
           tsConfigFilePath: options.tsConfigFilePath,
-          rootModuleFilePath: callerFilePath,
+          rootModuleFilePath: options.rootModuleFilePath ?? callerFilePath,
           schemaFileImports: options.schemaFileImports,
           context: options.context,
         }),


### PR DESCRIPTION
Allow configuring `rootModuleFilePath`. This helps generation of server.ts correctly when running nestjs with bundled js.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional configuration option `rootModuleFilePath` to enhance module path detection flexibility
  - Improved `TRPCModule.forRoot()` method to support explicit or auto-detected module file paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->